### PR TITLE
utilize rand/v2 on >=go1.22

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.18"
+          go-version: stable
       - run: go test -coverprofile=coverage.txt -covermode=atomic
       - uses: codecov/codecov-action@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         go:
           - "1.13"
@@ -17,13 +18,15 @@ jobs:
           - "1.21"
           - "1.22"
           - "1.23"
+          - "1.24"
     name: Go ${{ matrix.go }} test
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Install Go
+      - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
+          cache: false
       - name: Test
         run: go test -race ./...

--- a/rand.go
+++ b/rand.go
@@ -1,0 +1,17 @@
+//go:build !go1.22
+// +build !go1.22
+
+package jitter
+
+import "math/rand"
+
+// randRange returns a nonnegative pseudo-random number in the half open
+// interval [min, max) from the default Source.
+//
+// It panics if max < min.
+func randRange(min, max int64) int64 {
+	if min == max {
+		return min
+	}
+	return rand.Int63n(max-min) + min
+}

--- a/rand_go1.22.go
+++ b/rand_go1.22.go
@@ -1,0 +1,17 @@
+//go:build go1.22
+// +build go1.22
+
+package jitter
+
+import "math/rand/v2"
+
+// randRange returns a nonnegative pseudo-random number in the half open
+// interval [min, max) from the default Source.
+//
+// It panics if max < min.
+func randRange(min, max int64) int64 {
+	if min == max {
+		return min
+	}
+	return rand.Int64N(max-min) + min
+}

--- a/scale.go
+++ b/scale.go
@@ -1,8 +1,5 @@
 // Package jitter provides functionality for generating durations and tickers
 // that deviate from true periodicity within specified bounds.
-//
-// All functionality in this package currently utilizes global rand, so you will
-// want to seed it before utilization.
 package jitter
 
 /*
@@ -14,7 +11,6 @@ instead, which is very full featured and contains its own jitter support.
 import (
 	"errors"
 	"math"
-	"math/rand"
 	"time"
 )
 
@@ -52,15 +48,4 @@ func scaleBounds(n int64, f float64) (min, max int64) {
 		return int64(minf), math.MaxInt64
 	}
 	return int64(minf), int64(maxf)
-}
-
-// randRange returns a nonnegative pseudo-random number in the half open
-// interval [min, max) from the default Source.
-//
-// It panics if max < min.
-func randRange(min, max int64) int64 {
-	if min == max {
-		return min
-	}
-	return rand.Int63n(max-min) + min
 }


### PR DESCRIPTION
On versions of Go from 1.22 and newer, utilize the `rand/v2` package for global randomness generation.